### PR TITLE
fix parsing of testsuite name (within testsuites) and added package

### DIFF
--- a/test.py
+++ b/test.py
@@ -87,3 +87,9 @@ class Test4(X, TestCase):
 
     def test_props(self):
         assert self.ts.properties['assert-passed'] == '1'
+
+    def test_name_has_been_parsed_within_testsuites(self):
+        assert self.ts.name == 'base_test_1'
+
+    def test_testsuite_package_has_been_parsed(self):
+        assert self.ts.package == 'testdb'

--- a/xunitparser.py
+++ b/xunitparser.py
@@ -142,7 +142,6 @@ class Parser(object):
 
         tr = ts.run(self.TR_CLASS())
 
-        ts.name = root.attrib.get('name')
         tr.time = to_timedelta(root.attrib.get('time'))
 
         # check totals if they are in the root XML element
@@ -159,6 +158,8 @@ class Parser(object):
 
     def parse_testsuite(self, root, ts):
         assert root.tag == 'testsuite'
+        ts.name = root.attrib.get('name')
+        ts.package = root.attrib.get('package')
         for el in root:
             if el.tag == 'testcase':
                 self.parse_testcase(el, ts)


### PR DESCRIPTION
- a testsuite within a testsuites root would not have its name set
- a testsuite's package was not parsed
