### PR TITLE
Set time to None if time value is 'NaN'

### DIFF
--- a/test.py
+++ b/test.py
@@ -125,3 +125,10 @@ class Test6(X, TestCase):
 
 class Test7(X, TestCase):
     FILENAME = 'test7.xml'
+
+
+class Test8(X, TestCase):
+    FILENAME = 'test8.xml'
+
+    def test_bad_suite_time(self):
+        assert self.tr.time is None

--- a/tests/test8.xml
+++ b/tests/test8.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<testsuite errors='0' failures='0' name='test.suite.bad.time' tests='1' time='NaN' >
+  <testcase name="reallyFastTest" time="0"/>
+</testsuite>

--- a/xunitparser.py
+++ b/xunitparser.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 from datetime import timedelta
 from xml.etree import ElementTree
@@ -6,7 +7,12 @@ from xml.etree import ElementTree
 def to_timedelta(val):
     if val is None:
         return None
-    return timedelta(seconds=float(val))
+
+    secs = float(val)
+    if math.isnan(secs):
+        return None
+
+    return timedelta(seconds=secs)
 
 
 class TestResult(unittest.TestResult):


### PR DESCRIPTION
One of the test reporters we use (and can't change) will occasionally report 'NaN' in the testsuite time.
