### PR TITLE
Support Nested testsuite Elements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,11 +10,14 @@ Nicolas Léveillé <nicolas@uucidl.com>
 Damien Nozay <damien.nozay@gmail.com>
     * Added support for system-out / system-err at the testsuite level
 
-Josh Goodson <joshua.goodson@webfilings.com>
+Josh Goodson <joshua.goodson@workiva.com>
     * Various fixes, new tests
 
 Kevin Frommelt <kevin.frommelt@gmail.com>
     * Added support for NaN
+
+Kenny Trytek <kenny.trytek@workiva.com>
+    * Added support for nested testsuite elements
 
 Thanks to:
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 import os
-from unittest import TestCase
+from unittest import TestCase, main
 
 from xunitparser import parse
 
@@ -132,3 +132,15 @@ class Test8(X, TestCase):
 
     def test_bad_suite_time(self):
         assert self.tr.time is None
+
+
+class Test9(X, TestCase):
+    FILENAME = 'test9.xml'
+
+    def test_nested_testsuites(self):
+        self.assertIs(self.tr.testsRun, 2)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/tests/test9.xml
+++ b/tests/test9.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+    <testsuite name="suite1" failures="0" skipped="0" tests="1" time="0.005">
+        <testcase name="yo" time="0" status="0"/>
+        <testsuite name="suite2" failures="0" skipped="0" tests="1" time="0.002">
+            <testcase name="yo" time="0" status="0"/>
+        </testsuite>
+    </testsuite>
+</testsuites>

--- a/xunitparser.py
+++ b/xunitparser.py
@@ -169,6 +169,8 @@ class Parser(object):
         ts.name = root.attrib.get('name')
         ts.package = root.attrib.get('package')
         for el in root:
+            if el.tag == 'testsuite':
+                self.parse_testsuite(el, ts)
             if el.tag == 'testcase':
                 self.parse_testcase(el, ts)
             if el.tag == 'properties':


### PR DESCRIPTION
Laurent,

This PR contains the changes necessary for xunitparser to support nested testsuite elements. For a use case, please see this discussion about it:
https://github.com/theintern/intern/issues/275

"The Intern" produces xml with nested testsuites, and Jenkins has changed to support it, so it seems likely that the format cannot be long ignored.

If you need anything else, please let me know.

@laurentb 
