### PR TITLE
Fix empty testcases by setting _cleanup to False

### DIFF
--- a/xunitparser.py
+++ b/xunitparser.py
@@ -128,6 +128,7 @@ class TestSuite(unittest.TestSuite):
         self.properties = {}
         self.stdout = None
         self.stderr = None
+        self._cleanup = False
 
 
 class Parser(object):


### PR DESCRIPTION
In python3 BaseTestSuite has a class property _cleanup = False, which clears all testcases after TestSuite.run() is executed

This is fix for https://github.com/laurentb/xunitparser/issues/10
